### PR TITLE
Update workflow to use self-hosted runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ jobs:
   CodeQL-Build:
 
     # CodeQL runs on ubuntu-latest and windows-latest
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   test-e2e:
     name: Run end-to-end tests
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v2
       - name: Setup k3s

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v1
       - name: Setup Python

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint-go:
     name: Lint Go code
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
           args: --timeout 5m
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -61,7 +61,7 @@ jobs:
 
   codegen:
     name: Verify Codegen
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       GOPATH: /home/runner/go
       PROTOC_ZIP: protoc-3.12.3-linux-x86_64.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release-images:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout
@@ -108,7 +108,7 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   release-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout


### PR DESCRIPTION
We have optimized GitHub Runners to enhance resource utilization and efficiency by reducing the default packages loaded by runners. Introducing new runner groups for better customization and performance

---
### Note: New runners are deployed as minimal environments without pre-installed software like .NET. You'll need to install any required dependencies within your workflow.

For example: Following code snippet installs dotnet v3.1. For more information visit https://github.com/actions/setup-dotnet
```
    steps:
    - uses: actions/checkout@v4
    - uses: actions/setup-dotnet@v4
    with:
        dotnet-version: '3.1.x'
    - run: dotnet build <my project>
```

For more information checkout https://betssongroup.atlassian.net/wiki/spaces/TTM/pages/428605820/Transition+repositories+to+new+dedicated+runner+group

New runners include labels for example:
- `self-hosted` `X64` `Linux` `d-s` `default-standard`
- `self-hosted` `X64` `Linux` `d-l` `default-large`
>Builds should be compatible with both `x86-64` and `ARM64` architectures. If necessary, you can specify the architecture in the workflow

The assignment of runners depends not only on these labels but also based on the repository's association with specific runner groups and corresponding github apps managed by the CloudOps team.